### PR TITLE
:ox: Updating to current version of oxmysql (2.6.0)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -84,7 +84,7 @@ local function CreateObjectId()
 end
 
 local function IsVehicleOwned(plate)
-    local result = MySQL.Sync.fetchScalar('SELECT plate FROM player_vehicles WHERE plate = ?', {plate})
+    local result = MySQL.scalar.await('SELECT plate FROM player_vehicles WHERE plate = ?', {plate})
     return result
 end
 
@@ -341,7 +341,7 @@ end)
 AddEventHandler('onResourceStart', function(resourceName)
     if resourceName == GetCurrentResourceName() then
         CreateThread(function()
-            MySQL.Async.execute("DELETE FROM stashitems WHERE stash='policetrash'")
+            MySQL.query.await("DELETE FROM stashitems WHERE stash='policetrash'")
         end)
     end
 end)


### PR DESCRIPTION
Requires: oxmysql update 2.6.0
----------------------------------------------------------------------------------------------------------------------------------------------------------------
Issue: Current mysql calls are outdated. 

Fix: Update the oxmysql calls to current.

Expected result: We can now to update to the newest version of oxmysql and have the resource interact without errors. Saving and loading should work as normal. 