### PR TITLE
Clean code and better code

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -181,19 +181,21 @@ RegisterNetEvent('police:client:OpenArmory', function()
         slots = 30,
         items = {}
     }
-    -- local index = 1
-    for index, armoryItem in pairs(Config.Items.items) do
-        for i=1, #armoryItem.authorizedJobGrades do
-            if armoryItem.authorizedJobGrades[i] == PlayerJob.grade.level then
-                authorizedItems.items[index] = armoryItem
-                authorizedItems.items[index].slot = index
-                -- index = index + 1
+
+    for index, armoryItem in ipairs(Config.Items.items) do
+        for _, authorizedJobGrade in ipairs(armoryItem.authorizedJobGrades) do
+            if authorizedJobGrade == PlayerJob.grade.level then
+                armoryItem.slot = index
+                table.insert(authorizedItems.items, armoryItem)
+                break  -- Exit the loop after finding a match
             end
         end
     end
+
     SetWeaponSeries()
     TriggerServerEvent("inventory:server:OpenInventory", "shop", "police", authorizedItems)
 end)
+
 
 -- Threads
 

--- a/client/job.lua
+++ b/client/job.lua
@@ -21,7 +21,7 @@ local FingerPrintSessionId = nil
 
 function CreatePrompts()
     for k,v in pairs(Config.Locations['duty']) do
-        exports['qbr-core']:createPrompt('duty_prompt_' .. k, v, 0xF3830D8E, 'Toggle duty status', {
+        exports['qbr-core']:createPrompt('duty_prompt_' .. k, v, 0xF3830D8E, Lang:t('prompt.toggle_duty_status'), {
             type = 'client',
             event = 'qb-policejob:ToggleDuty',
             args = {},
@@ -29,7 +29,7 @@ function CreatePrompts()
     end
 
     for k,v in pairs(Config.Locations['evidence']) do
-        exports['qbr-core']:createPrompt('evidence_prompt_' .. k, v, 0xF3830D8E, 'Open Evidence Stash', {
+        exports['qbr-core']:createPrompt('evidence_prompt_' .. k, v, 0xF3830D8E, Lang:t('prompt.open_evidence_stash'), {
             type = 'client',
             event = 'police:client:EvidenceStashDrawer',
             args = { k },
@@ -37,7 +37,7 @@ function CreatePrompts()
     end
 
     for k,v in pairs(Config.Locations['stash']) do
-        exports['qbr-core']:createPrompt('stash_prompt_' .. k, v, 0xF3830D8E, 'Open Personal Stash', {
+        exports['qbr-core']:createPrompt('stash_prompt_' .. k, v, 0xF3830D8E, Lang:t('prompt.open_personal_stash'), {
             type = 'client',
             event = 'police:client:OpenPersonalStash',
             args = {},
@@ -45,7 +45,7 @@ function CreatePrompts()
     end
 
     for k,v in pairs(Config.Locations['armory']) do
-        exports['qbr-core']:createPrompt('armory_prompt_' .. k, v, 0xF3830D8E, 'Open Armory', {
+        exports['qbr-core']:createPrompt('armory_prompt_' .. k, v, 0xF3830D8E, Lang:t('prompt.open_armory'), {
             type = 'client',
             event = 'police:client:OpenArmory',
             args = {},
@@ -91,12 +91,17 @@ local function IsArmoryWhitelist() -- being removed
 end
 
 local function SetWeaponSeries()
-    for k, v in pairs(Config.Items.items) do
+    for k, v in ipairs(Config.Items.items) do
         if k < 6 then
-            Config.Items.items[k].info.serie = tostring(exports['qbr-core']:RandomInt(2) .. exports['qbr-core']:RandomStr(3) .. exports['qbr-core']:RandomInt(1) .. exports['qbr-core']:RandomStr(2) .. exports['qbr-core']:RandomInt(3) .. exports['qbr-core']:RandomStr(4))
+            local randomInt = exports['qbr-core']:RandomInt
+            local randomStr = exports['qbr-core']:RandomStr
+
+            local serie = tostring(randomInt(2) .. randomStr(3) .. randomInt(1) .. randomStr(2) .. randomInt(3) .. randomStr(4))
+            Config.Items.items[k].info.serie = serie
         end
     end
 end
+
 
 RegisterNetEvent('police:client:ImpoundVehicle', function(fullImpound, price)
     local vehicle = exports['qbr-core']:GetClosestVehicle()

--- a/client/main.lua
+++ b/client/main.lua
@@ -148,7 +148,7 @@ RegisterNetEvent('police:client:UpdateBlips', function(players)
             if players then
                 for k, data in pairs(players) do
                     local id = GetPlayerFromServerId(data.source)
-                    CreateDutyBlips(id, data.label, data.job, data.location)
+                    CreateDutyBlip(id, data.label, data.job, data.location)
                 end
             end
         end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -180,6 +180,12 @@ local Translations = {
         place_object = 'Placing object..',
         remove_object = 'Removing object..',
     },
+    prompt = {
+        toggle_duty_status = 'Toggle duty status',
+        open_evidence_stash = 'Open Evidence Stash',
+        open_personal_stash = 'Open Personal Stash',
+        open_armory = 'Open Armory',
+    },
 }
 
 Lang = Locale:new({

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -180,6 +180,12 @@ local Translations = {
         place_object = 'Colocando objeto..',
         remove_object = 'Eliminando objeto..',
     },
+    prompt = {
+        toggle_duty_status = 'Alternar estado de servicio',
+        open_evidence_stash = 'Abrir inventario de pruebas',
+        open_personal_stash = 'Abrir inventario personal',
+        open_armory = 'Armería Abierta',
+    },
 }
 
 if GetConvar('qbr_locale', 'en') == 'es' then

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -184,7 +184,7 @@ local Translations = {
         toggle_duty_status = 'Alternar estado de servicio',
         open_evidence_stash = 'Abrir inventario de pruebas',
         open_personal_stash = 'Abrir inventario personal',
-        open_armory = 'Armería Abierta',
+        open_armory = 'Abrir Armería',
     },
 }
 


### PR DESCRIPTION
Clean code and better code

job.lua -> police:client:policeAlert
    The unnecessary while loop was removed, and the logic for removing blips at the end of the function was simplified.

client/main.lua -> police:client:OpenArmory
    Used ipairs for the outer loop for better readability.
    Used table.insert to add items to the authorizedItems.items table.
    Removed the commented-out code and unnecessary local variable (index).
    Used a more descriptive variable name (authorizedJobGrade) in the inner loop.
    Added a break statement to exit the inner loop once an authorized job grade is found, improving efficiency.